### PR TITLE
Allow specifying the PEAR version installed via wadf

### DIFF
--- a/WADF.php
+++ b/WADF.php
@@ -1222,7 +1222,9 @@ class Tools_WADF {
 					
 				$this->_debugOutput("PEAR dependencies found; creating a PEAR installation in $pear_path (config file is $pear_config_file)...", self::DEBUG_GENERAL);
 				
-				$cmd = "pear ".$this->_getPEARVerbosity()." -c $pear_config_file install --onlyreqdeps pear.php.net/PEAR";
+				$pear_version = $this->resolveMacro('dep_pear_restrict_version');
+				$pear_package = empty($pear_version) ?  'pear.php.net/PEAR' : "pear.php.net/PEAR-{$pear_version}";
+				$cmd = "pear {$this->_getPEARVerbosity()} -c {$pear_config_file} install --onlyreqdeps {$pear_package}";
 				$this->_runPEAR($cmd);
 				$this->_runPEAR("channel-update pear", false, false);
 			}

--- a/WADF.php
+++ b/WADF.php
@@ -1229,7 +1229,7 @@ class Tools_WADF {
 				$this->_runPEAR("channel-update pear", false, false);
 			}
 		} else {
-			$this->_runPEAR($this->_getPEARCmd() . ' config-get bin_dir', $output);
+			$output = $this->_runPEAR($this->_getPEARCmd() . ' config-get bin_dir');
 			$pear_path = $output[0];
 			$this->_debugOutput("Using existing PEAR installation in $pear_path", self::DEBUG_INFORMATION);
 		}

--- a/wadf.conf
+++ b/wadf.conf
@@ -70,7 +70,7 @@ php_config_location = php.ini
 php_config_location_extra =
 
 ; how to restart the webserver
-webserver_restart_cmd = 
+webserver_restart_cmd =
 
 ; where to find the template vhost config within an app's directory, relative
 ; to the root of the directory
@@ -162,10 +162,10 @@ vhost_config_path = @home@/.wadf/vhosts
 ; Prepend or append text inside the virtual host configuration
 ; Currently if there is more than one vhost these will be prepended/appended to
 ; ALL the vhosts.
-; You can use "\n" to insert a new line and "\t" to insert a tab e.g. 
+; You can use "\n" to insert a new line and "\t" to insert a tab e.g.
 ; vhost_config_append = "\t<Directory />\n\t\tOptions +Indexes\n\t</Directory"
-vhost_config_append = 
-vhost_config_prepend = 
+vhost_config_append =
+vhost_config_prepend =
 
 ; Default vhost name (generic)
 vhost_name = @instance@@vhost_number@.@deploy_domain@
@@ -177,16 +177,16 @@ vhost_interface = *
 ; script which populates the database with initial values etc.)
 kickstart_script = @deploy_path@/setup.php
 
-; Script which is run after ALL file-base deployment is complete (including 
+; Script which is run after ALL file-base deployment is complete (including
 ; running kickstart_script) but BEFORE webserver_restart_cmd
 ; Useful on live servers for running something like a script that runs as a
 ; privileged process to copy processed configurations to the right place
-post_deploy_script = 
+post_deploy_script =
 
 ; Which file contains the scheduled job information
 crontab = @deploy_path@/crontab
 
-; Files to cleanup after deployment. Files are only cleaned up if they are 
+; Files to cleanup after deployment. Files are only cleaned up if they are
 ; GENERATED files; that is, if the file also exists with a ".template"
 ; extension, unless you prefix the file with "+", in which case it is removed
 ; anyway.
@@ -203,7 +203,7 @@ generated_files_writeable = false
 
 ; Comma-separated list of paths to exclude from templating, relative to
 ; @deploy_path@ e.g. "svn_checkouts/", "foo/bar/z.template"
-template_exclude_paths = 
+template_exclude_paths =
 
 ; which profile to use for this machine
 profile = local
@@ -275,9 +275,13 @@ dep_pear_clear_cache = no
 dep_pear_bug_workarounds = bug13425, bug13427
 
 ; Directories to look in to find local copies of PEAR packages (e.g. checkouts
-; from version control). Relative to @deploy_path@ . Separate multiple 
+; from version control). Relative to @deploy_path@ . Separate multiple
 ; directories with commas.
-dep_pear_local_package_dirs = 
+dep_pear_local_package_dirs =
+
+; Restrict version of installed pear/PEAR package in case the latest stable has
+; compatibility issues.
+dep_pear_restrict_version =
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; PROFILES

--- a/wadf.conf
+++ b/wadf.conf
@@ -70,7 +70,7 @@ php_config_location = php.ini
 php_config_location_extra =
 
 ; how to restart the webserver
-webserver_restart_cmd =
+webserver_restart_cmd = 
 
 ; where to find the template vhost config within an app's directory, relative
 ; to the root of the directory
@@ -162,10 +162,10 @@ vhost_config_path = @home@/.wadf/vhosts
 ; Prepend or append text inside the virtual host configuration
 ; Currently if there is more than one vhost these will be prepended/appended to
 ; ALL the vhosts.
-; You can use "\n" to insert a new line and "\t" to insert a tab e.g.
+; You can use "\n" to insert a new line and "\t" to insert a tab e.g. 
 ; vhost_config_append = "\t<Directory />\n\t\tOptions +Indexes\n\t</Directory"
-vhost_config_append =
-vhost_config_prepend =
+vhost_config_append = 
+vhost_config_prepend = 
 
 ; Default vhost name (generic)
 vhost_name = @instance@@vhost_number@.@deploy_domain@
@@ -177,16 +177,16 @@ vhost_interface = *
 ; script which populates the database with initial values etc.)
 kickstart_script = @deploy_path@/setup.php
 
-; Script which is run after ALL file-base deployment is complete (including
+; Script which is run after ALL file-base deployment is complete (including 
 ; running kickstart_script) but BEFORE webserver_restart_cmd
 ; Useful on live servers for running something like a script that runs as a
 ; privileged process to copy processed configurations to the right place
-post_deploy_script =
+post_deploy_script = 
 
 ; Which file contains the scheduled job information
 crontab = @deploy_path@/crontab
 
-; Files to cleanup after deployment. Files are only cleaned up if they are
+; Files to cleanup after deployment. Files are only cleaned up if they are 
 ; GENERATED files; that is, if the file also exists with a ".template"
 ; extension, unless you prefix the file with "+", in which case it is removed
 ; anyway.
@@ -203,7 +203,7 @@ generated_files_writeable = false
 
 ; Comma-separated list of paths to exclude from templating, relative to
 ; @deploy_path@ e.g. "svn_checkouts/", "foo/bar/z.template"
-template_exclude_paths =
+template_exclude_paths = 
 
 ; which profile to use for this machine
 profile = local
@@ -275,9 +275,9 @@ dep_pear_clear_cache = no
 dep_pear_bug_workarounds = bug13425, bug13427
 
 ; Directories to look in to find local copies of PEAR packages (e.g. checkouts
-; from version control). Relative to @deploy_path@ . Separate multiple
+; from version control). Relative to @deploy_path@ . Separate multiple 
 ; directories with commas.
-dep_pear_local_package_dirs =
+dep_pear_local_package_dirs = 
 
 ; Restrict version of installed pear/PEAR package in case the latest stable has
 ; compatibility issues.


### PR DESCRIPTION
A new wadf.conf macro `dep_pear_restrict_version` can restrict which pear/PEAR version is installed; e.g. setting
`dep_pear_restrict_version = 1.10.9`
will install `pear.php.net/PEAR-1.10.9`.

Leaving the macro empty (default setting) will install the latest PEAR, as before.
